### PR TITLE
Remove IDs from sentry messages

### DIFF
--- a/app/services/reschedule_tasks_for_missing_runners.rb
+++ b/app/services/reschedule_tasks_for_missing_runners.rb
@@ -36,18 +36,18 @@ class RescheduleTasksForMissingRunners
         runner: slot&.node&.runner_provider,
         runner_id: runner_id,
         slot: {
-          id: slot&.id,
+          uuid: slot&.uuid,
           name: slot&.name,
           status: slot&.status,
           runner_id: slot&.runner_id
         },
         node: {
-          id: node&.id,
+          uuid: node&.uuid,
           name: node&.name,
           status: node&.status
         },
         task: {
-          id: task.id,
+          uuid: task.uuid,
           name: task.name,
           status: task.status
         }

--- a/app/services/reschedule_tasks_for_missing_runners.rb
+++ b/app/services/reschedule_tasks_for_missing_runners.rb
@@ -11,7 +11,7 @@ class RescheduleTasksForMissingRunners
   def perform
     tasks_without_runner.each do |runner_id|
       task = started_tasks_group_by_runner_id[runner_id]
-      message = "Task retryied because runner #{runner_id} is missing (#{task} #{task&.slot})"
+      message = "Task retried because runner is missing"
       Rails.logger.debug(message)
 
       report_event(message: message, task: task, runner_id: runner_id)

--- a/spec/services/reschedule_tasks_for_missing_runners_spec.rb
+++ b/spec/services/reschedule_tasks_for_missing_runners_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe RescheduleTasksForMissingRunners, type: :service do
 
       it "sends an event" do
         expect(Raven).to receive(:capture_exception).with(
-          "Task retryied because runner #{runner_id} is missing (#{started_task} #{slot})",
+          "Task retried because runner is missing",
           level: :info,
           extra: {
             runner: node.runner_provider,

--- a/spec/services/reschedule_tasks_for_missing_runners_spec.rb
+++ b/spec/services/reschedule_tasks_for_missing_runners_spec.rb
@@ -54,18 +54,18 @@ RSpec.describe RescheduleTasksForMissingRunners, type: :service do
             runner: node.runner_provider,
             runner_id: runner_id,
             slot: {
-              id: slot.id,
+              uuid: slot.uuid,
               name: slot.name,
               status: slot.status,
               runner_id: slot.runner_id
             },
             node: {
-              id: node.id,
+              uuid: node.uuid,
               name: node.name,
               status: node.status
             },
             task: {
-              id: started_task.id,
+              uuid: started_task.uuid,
               name: started_task.name,
               status: started_task.status
             }


### PR DESCRIPTION
Remove IDs from Sentry messages to allow them to be grouped on Sentry. 
As every message has the ID interpolated it is not possible to group this warnings.